### PR TITLE
[ColorUtils] added InvertColor method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ String contrastColor(String hex);
 Map<String, int> basicColorsFromHex(String hex);
 double calculateRelativeLuminance(int red, int green, int blue,{int decimals = 2});
 List<String> swatchColor(String hex, {double percentage = 15, int amount = 5});
+String invertColor(String color);
 ```
 
 ### DateUtils

--- a/lib/src/ColorUtils.dart
+++ b/lib/src/ColorUtils.dart
@@ -196,8 +196,11 @@ class ColorUtils {
   static String invertColor(String color) {
     List<String> invertedColor = List<String>();
     for (int i = 0; i < color.length; i++) {
+      if (color[i].startsWith("#"))
+        invertedColor.add("#");
+      else
       invertedColor.add(
-          ((~hexToInt(color[i])).toUnsigned(4)).toRadixString(16));
+          ((~int.parse("0x${color[i]}")).toUnsigned(4)).toRadixString(16));
     }
     return invertedColor.join();
   }

--- a/lib/src/ColorUtils.dart
+++ b/lib/src/ColorUtils.dart
@@ -186,4 +186,19 @@ class ColorUtils {
     }
     return colors;
   }
+  
+  /// 
+  /// Inverts Color Hex code
+  /// Convert string to (4-bit int) and apply bitwise-NOT operation then convert back to Hex String
+  /// e.g: convert white (FFFFFF) to Dark (000000).
+  /// Returns Inverted String Color.
+  ///
+  static String invertColor(String color) {
+    List<String> invertedColor = List<String>();
+    for (int i = 0; i < color.length; i++) {
+      invertedColor.add(
+          ((~hexToInt(color[i])).toUnsigned(4)).toRadixString(16));
+    }
+    return invertedColor.join();
+  }
 }

--- a/test/color_utils_test.dart
+++ b/test/color_utils_test.dart
@@ -67,5 +67,7 @@ void main() {
     expect(ColorUtils.invertColor("#FFFFFF"), "#000000");
     expect(ColorUtils.invertColor("#FF00FF"), "#00ff00");
     expect(ColorUtils.invertColor("000000"), "ffffff");
+    expect(ColorUtils.invertColor("#FFA8FF"), "#005700");
+
   });
 }

--- a/test/color_utils_test.dart
+++ b/test/color_utils_test.dart
@@ -62,4 +62,10 @@ void main() {
     expect(colors.elementAt(9), '#621b16');
     expect(colors.elementAt(10), '#3d110e');
   });
+  
+    test('Test invert color', () {
+    expect(ColorUtils.invertColor("#FFFFFF"), "#000000");
+    expect(ColorUtils.invertColor("#FF00FF"), "#00ff00");
+    expect(ColorUtils.invertColor("000000"), "ffffff");
+  });
 }


### PR DESCRIPTION
**Use case:**
I was trying to display a CircleAvatar with different background-colors and add a check Icon when pressed. 
The problem that I came into is that `Icon(Icons.check)` color is the same every time (it was white) which in this case doesn't appear on a CircleAvatar with the white background obviously.

I needed a solution to change that Icon dynamically. So I came up with the following: 

**Logic:** 
Get the inverted color of the CircleAvatar's background color by converting color's hex string value to (4-bit int) and apply bitwise-NOT operation then convert back to Hex String. 

The following screenshots demonstrate the use case that I mentioned.

![flutter_05](https://user-images.githubusercontent.com/38144217/94568864-b53c7700-0275-11eb-90d6-ce8653556233.png)


![flutter_04](https://user-images.githubusercontent.com/38144217/94568860-b40b4a00-0275-11eb-82f8-c7a1676e8dd9.png)
