### PR TITLE
Added FunctionDefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A dart package for many helper methods fitting different situations.
     - [IterableUtils](#iterableutils)
     - [CryptoUtils](#cryptoutils)
     - [ASN1Utils](#asn1utils)
+    - [FunctionDefs](#functionDefs)
   - [Changelog](#changelog)
   - [Real Live Examples](#real-live-examples)
     - [SSL Toolkit](#ssl-toolkit)
@@ -289,6 +290,23 @@ Helper class for operation on ASN1 objects.
 
 ```dart
 String dump(String pem);
+```
+
+### FunctionDefs
+
+Helper with various function prototype definitions.
+
+```
+BiConsumer<T,U>
+BiFunction<T,U,R>
+BinaryOperator<T>
+BiPredicate<T,U>
+Consumer<T>
+Supplier<T>
+BooleanSupplier
+SingleFunction<T,R>
+Predicate<T>
+UnaryOperator<T>
 ```
 
 ## Changelog

--- a/lib/basic_utils.dart
+++ b/lib/basic_utils.dart
@@ -44,6 +44,7 @@ export 'src/X509Utils.dart';
 export 'src/IterableUtils.dart';
 export 'src/CryptoUtils.dart';
 export 'src/Asn1Utils.dart';
+export 'src/FunctionDefs.dart';
 
 // Export other libraries
 export 'package:pointycastle/ecc/api.dart';

--- a/lib/src/FunctionDefs.dart
+++ b/lib/src/FunctionDefs.dart
@@ -1,0 +1,34 @@
+
+/// Represents a function that accepts two arguments and produces a result.
+typedef BiFunction<T,U,R> = R Function(T first, U second);
+
+/// Represents an operation that accepts two input arguments and returns no
+/// result
+typedef BiConsumer<T,U> = BiFunction<T, U, void>;
+
+/// Represents an operation upon two operands of the same type, producing a
+/// result of the same type as the operands.
+typedef BinaryOperator<T> = BiFunction<T, T, T>;
+
+/// Represents a predicate (boolean-valued function) of two arguments.
+typedef BiPredicate<T,U> = BiFunction<T, U, bool>;
+
+/// Represents a supplier of results.
+typedef Supplier<T> = T Function();
+
+/// Represents a supplier of boolean-valued results.
+typedef BooleanSupplier = Supplier<bool>;
+
+/// Represents a function that accepts one argument and produces a result.
+typedef SingleFunction<T,R> = R Function(T arg);
+
+/// Represents an operation that accepts a single input argument and returns no
+/// result.
+typedef Consumer<T> = SingleFunction<T, void>;
+
+/// Represents a predicate (boolean-valued function) of one argument.
+typedef Predicate<T> = SingleFunction<T, bool>;
+
+/// Represents an operation on a single operand that produces a result of the
+/// same type as its operand.
+typedef UnaryOperator<T> = SingleFunction<T, T>;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -492,4 +492,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.13.0 <3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -492,4 +492,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/Ephenodrom/Dart-Basic-Utils
 publish_to: https://pub.dartlang.org
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.13.0 <3.0.0'
 
 dependencies:
   http: ^0.13.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/Ephenodrom/Dart-Basic-Utils
 publish_to: https://pub.dartlang.org
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
   http: ^0.13.3


### PR DESCRIPTION
As a Java developer I missed having some standard function definitions in Dart, so I took some definitions from Java's [function package](https://docs.oracle.com/javase/8/docs/api/java/util/function/package-summary.html) and ported them to Dart. I thought others might find this helpful as well.

This change requires a later Dart version since it uses type aliasing which was [introduced in Dart 2.13](https://medium.com/dartlang/announcing-dart-2-13-c6d547b57067)