### PR TITLE
Exporting EnumUtils.dart

### DIFF
--- a/lib/basic_utils.dart
+++ b/lib/basic_utils.dart
@@ -49,6 +49,7 @@ export 'src/IterableUtils.dart';
 export 'src/CryptoUtils.dart';
 export 'src/Asn1Utils.dart';
 export 'src/FunctionDefs.dart';
+export 'src/EnumUtils.dart';
 
 // Export other libraries
 export 'package:pointycastle/ecc/api.dart';


### PR DESCRIPTION
EnumUtils.dart wasn't exported in version 4.0.0