### PR TITLE
Change addQueryParameterToUrl to handle URLs with existing query parameters

### DIFF
--- a/lib/src/HttpUtils.dart
+++ b/lib/src/HttpUtils.dart
@@ -268,11 +268,18 @@ class HttpUtils {
   }
 
   ///
-  /// Add the given [queryParameters] to the given [url].
+  /// Add the given [queryParameters] to the given [url]. If the key for a parameter already exists then it is overwritten.
   ///
   static String addQueryParameterToUrl(
       String url, Map<String, dynamic>? queryParameters) {
     if (queryParameters == null || queryParameters.isEmpty) return url;
+
+    final existingQueryParameters = getQueryParameterFromUrl(url);
+
+    if (existingQueryParameters != null) {
+      queryParameters.addAll(existingQueryParameters);
+    }
+
     return Uri.parse(url).replace(queryParameters: queryParameters).toString();
   }
 

--- a/test/http_utils_test.dart
+++ b/test/http_utils_test.dart
@@ -16,6 +16,17 @@ void main() {
         'super-api.com/dosomething?hello=world&list%5B%5D=item1&list%5B%5D=item2');
   });
 
+  test('Test addQueryParameterToUrl for url with existing query parameters',
+      () {
+    var queryParameters = <String, dynamic>{};
+    queryParameters.putIfAbsent('hello', () => 'world');
+    queryParameters.putIfAbsent('list[]', () => ['item1', 'item2']);
+    expect(
+        HttpUtils.addQueryParameterToUrl(
+            'super-api.com/dosomething?foo=bar', queryParameters),
+        'super-api.com/dosomething?hello=world&list%5B%5D=item1&list%5B%5D=item2&foo=bar');
+  });
+
   test('Test getQueryParameterFromUrl', () {
     expect(
         HttpUtils.getQueryParameterFromUrl('super-api.com/dosomething'), null);


### PR DESCRIPTION
Previously, `addQueryParameterToUrl` would remove existing query parameters on the URL. This change makes it so that `addQueryParameterToUrl` will maintain existing query parameters, however if there is a key for a parameter that already exists then it will be overwritten.