### PR TITLE
feat: Add optional ECDomainParameters to ec key from bytes method

### DIFF
--- a/lib/src/CryptoUtils.dart
+++ b/lib/src/CryptoUtils.dart
@@ -680,7 +680,7 @@ class CryptoUtils {
   /// Supports SEC1 (<https://tools.ietf.org/html/rfc5915>) and PKCS8 (<https://datatracker.ietf.org/doc/html/rfc5208>)
   ///
   static ECPrivateKey ecPrivateKeyFromDerBytes(Uint8List bytes,
-      {bool pkcs8 = false}) {
+      {bool pkcs8 = false, ECDomainParameters? parameters}) {
     var asn1Parser = ASN1Parser(bytes);
     var topLevelSeq = asn1Parser.nextObject() as ASN1Sequence;
     var curveName;
@@ -722,13 +722,17 @@ class CryptoUtils {
       x = privateKeyAsOctetString.valueBytes!;
     }
 
-    return ECPrivateKey(osp2i(x), ECDomainParameters(curveName));
+    return ECPrivateKey(
+      osp2i(x),
+      parameters ?? ECDomainParameters(curveName),
+    );
   }
 
   ///
   /// Decode the given [bytes] into an [ECPublicKey].
   ///
-  static ECPublicKey ecPublicKeyFromDerBytes(Uint8List bytes) {
+  static ECPublicKey ecPublicKeyFromDerBytes(Uint8List bytes,
+      {ECDomainParameters? parameters}) {
     if (bytes.elementAt(0) == 0) {
       bytes = bytes.sublist(1);
     }
@@ -759,7 +763,7 @@ class CryptoUtils {
     }
     var x = pubBytes.sublist(1, (pubBytes.length / 2).round());
     var y = pubBytes.sublist(1 + x.length, pubBytes.length);
-    var params = ECDomainParameters(curveName);
+    var params = parameters ?? ECDomainParameters(curveName);
     var bigX = decodeBigIntWithSign(1, x);
     var bigY = decodeBigIntWithSign(1, y);
     var pubKey = ECPublicKey(


### PR DESCRIPTION
Good morning ❤️ first of all thank you very much for your library. While playing around with it I ran into the problem that I wasn't able to import private/public ec keys when they use the curve `brainpoolP256r1`. I've got the error message from pointycastle: `No algorithm registered of type ECDomainParameters with name: brainpoolP256r1"`

After some investigation I found out that this should be fixable by specifying this curve as a parameter first and use it in the constructor of the ECPrivateKey and ECPublicKey classes like this:

```dart
final parameters = ECCurve_brainpoolp256r1();
final key = ECPrivateKey(
      osp2i(x),
      parameters,
);
```

So I added two optional parameters to the `CryptoUtils.ecPrivateKeyFromDerBytes()` and `CryptoUtils.ecPublicKeyFromDerBytes()` methods to overwrite the ECDomainParameters for special EC Curves which worked fine for me locally. I thought the ***KeyFromDerBytes() methods looked like a good place as they already have the `bool pkcs8` optional parameter.