### PR TITLE
ECDSA Keypair SEC1 to Pkcs8 converting 

### DIFF
--- a/lib/src/CryptoUtils.dart
+++ b/lib/src/CryptoUtils.dart
@@ -1173,4 +1173,15 @@ class CryptoUtils {
   ///
   static Uint8List removePKCS7Padding(Uint8List padded) =>
       padded.sublist(0, padded.length - PKCS7Padding().padCount(padded));
+
+  ///
+  /// Encode a private ECDSA key to PKCS8 format
+  ///
+  static String encodePrivateEcdsaKeyToPkcs8(ECPrivateKey privateKey) {
+    final privateKeyPem = CryptoUtils.encodeEcPrivateKeyToPem(privateKey);
+    final base64Encoded = base64.encode(ASN1PrivateKeyInfo.fromEccPem(privateKeyPem).encode());
+    final base64Formatted = base64Encoded.replaceAllMapped(RegExp(r".{64}"), (match) => "${match.group(0)}\n");
+
+    return '$BEGIN_PRIVATE_KEY\n$base64Formatted\n$END_PRIVATE_KEY';
+  }
 }

--- a/test/crypto_utils_test.dart
+++ b/test/crypto_utils_test.dart
@@ -429,4 +429,11 @@ sF0zEAHkQoYVBEhrfAHOLYkE3u08+q2tug==
     );
     expect(pem, opensslEcKey);
   });
+
+  test('Test encodeEcPrivateKeyToPkcs8', () {
+    var ecdsaKeypair = CryptoUtils.generateEcKeyPair(); 
+    var ecPrivateKeyPkcs8 = CryptoUtils.encodePrivateEcdsaKeyToPkcs8(ecdsaKeypair.privateKey as ECPrivateKey); 
+
+    expect(ecPrivateKeyPkcs8.startsWith('-----BEGIN PRIVATE KEY-----'), true); 
+  });
 }


### PR DESCRIPTION
Hi :) 

To refer to this [issue](https://github.com/Ephenodrom/Dart-Basic-Utils/issues/99) that I opened, here is a PR to convert an Ecdsa keypair from Sec 1 format to Pkcs8 

- Converting an ECPrivateKey on Sec1 format to Pkcs8 
- Test it 

Let me know if anything goes wrong  :) 