### PR TITLE
Basic Constraints extension

### DIFF
--- a/lib/src/X509Utils.dart
+++ b/lib/src/X509Utils.dart
@@ -497,7 +497,10 @@ class X509Utils {
         basicConstraintsSequence.add(ASN1Boolean(true));
 
         var basicConstraintsList = ASN1Sequence();
-        basicConstraintsList.add(ASN1Boolean(cA));
+
+        if (cA) {
+          basicConstraintsList.add(ASN1Boolean(cA));
+        }
 
         // check if CA to allow pathLenConstraint
         if (pathLenConstraint != null && cA && pathLenConstraint >= 0) {
@@ -1444,6 +1447,28 @@ class X509Utils {
   }
 
   ///
+  /// Parses the given ASN1Object to the two basic constraint
+  /// fields cA and pathLenConstraint. Returns a list of types [bool, int] if
+  /// cA is true and a valid pathLenConstraint is specified, else the
+  /// corresponding element will be null.
+  ///
+  static List<dynamic> _fetchBasicConstraintsFromExtension(ASN1Object extData) {
+    var basicConstraints = <dynamic>[null, null];
+    var octet = extData as ASN1OctetString;
+    var constraintParser = ASN1Parser(octet.valueBytes);
+    var constraintSeq = constraintParser.nextObject() as ASN1Sequence;
+    constraintSeq.elements!.forEach((ASN1Object obj) {
+      if (obj is ASN1Boolean) {
+        basicConstraints[0] = obj.boolValue;
+      }
+      if (obj is ASN1Integer) {
+        basicConstraints[1] = obj.integer!.toInt();
+      }
+    });
+    return basicConstraints;
+  }
+
+  ///
   /// Parses the given object identifier values to the internal enum
   ///
   static List<KeyUsage> _fetchKeyUsageFromExtension(ASN1Object extData) {
@@ -1952,6 +1977,7 @@ class X509Utils {
     List<String>? sans;
     List<KeyUsage>? keyUsage;
     List<ExtendedKeyUsage>? extKeyUsage;
+    List<dynamic> basicConstraints;
     var extensions = X509CertificateDataExtensions();
     extSequence.elements!.forEach(
       (ASN1Object subseq) {
@@ -1987,6 +2013,17 @@ class X509Utils {
                 _fetchExtendedKeyUsageFromExtension(seq.elements!.elementAt(1));
           }
           extensions.extKeyUsage = extKeyUsage;
+        }
+        if (oi.objectIdentifierAsString == '2.5.29.19') {
+          if (seq.elements!.length == 3) {
+            basicConstraints =
+                _fetchBasicConstraintsFromExtension(seq.elements!.elementAt(2));
+          } else {
+            basicConstraints = [null, null];
+          }
+
+          extensions.cA = basicConstraints[0];
+          extensions.pathLenConstraint = basicConstraints[1];
         }
         if (oi.objectIdentifierAsString == '1.3.6.1.5.5.7.1.12') {
           var vmcData = _fetchVmcLogo(seq.elements!.elementAt(1));

--- a/lib/src/model/x509/X509CertificateDataExtensions.dart
+++ b/lib/src/model/x509/X509CertificateDataExtensions.dart
@@ -19,6 +19,12 @@ class X509CertificateDataExtensions {
   /// The key usage extension
   List<KeyUsage>? keyUsage;
 
+  /// The cA field of the basic constraints extension
+  bool? cA;
+
+  /// The pathLenConstraint field of the basic constraints extension
+  int? pathLenConstraint;
+
   /// The base64 encoded VMC logo
   VmcData? vmc;
 
@@ -29,6 +35,8 @@ class X509CertificateDataExtensions {
     this.subjectAlternativNames,
     this.extKeyUsage,
     this.keyUsage,
+    this.cA,
+    this.pathLenConstraint,
     this.vmc,
     this.cRLDistributionPoints,
   });

--- a/lib/src/model/x509/X509CertificateDataExtensions.g.dart
+++ b/lib/src/model/x509/X509CertificateDataExtensions.g.dart
@@ -18,6 +18,8 @@ X509CertificateDataExtensions _$X509CertificateDataExtensionsFromJson(
       keyUsage: (json['keyUsage'] as List<dynamic>?)
           ?.map((e) => $enumDecode(_$KeyUsageEnumMap, e))
           .toList(),
+      cA: json['cA'] as bool?,
+      pathLenConstraint: json['pathLenConstraint'] as int?,
       vmc: json['vmc'] == null
           ? null
           : VmcData.fromJson(json['vmc'] as Map<String, dynamic>),
@@ -41,6 +43,8 @@ Map<String, dynamic> _$X509CertificateDataExtensionsToJson(
       instance.extKeyUsage?.map((e) => _$ExtendedKeyUsageEnumMap[e]!).toList());
   writeNotNull('keyUsage',
       instance.keyUsage?.map((e) => _$KeyUsageEnumMap[e]!).toList());
+  writeNotNull('cA', instance.cA);
+  writeNotNull('pathLenConstraint', instance.pathLenConstraint);
   writeNotNull('vmc', instance.vmc?.toJson());
   writeNotNull('cRLDistributionPoints', instance.cRLDistributionPoints);
   return val;


### PR DESCRIPTION
#83  #103  

Hi! I recently made a Basic Constraints extension for myself in addition to this package. I was hoping I'd be able to contribute as I saw others requesting it. 

This pull request adds two new fields, cA and pathLenConstraint [(RFC reference)](https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.9) , both to the generateSelfSignedCertificate() function and X509CertificateDataExtensions class. 

As for behavior, 

1. There are combinations of the two fields that are invalid, for example: cA = false, pathLenConstraint = 9 and cA = true, pathLenConstraint = -2; generateSelfSignedCertificate() will ignore invalid inputs and not create the extension. I have documented these conditions, but please let me know if you would prefer warnings and/or errors for this rather than ignoring input.
2. The extension is always marked as critical.

Finally, another extension, Subject Key Identifier, is necessary for conforming cA certificates. I am currently working on this.

Thanks!