### PR TITLE
Add 'dnsApiUrl' parameter to lookupRecord function in DnsUtils class

### DIFF
--- a/lib/src/DnsUtils.dart
+++ b/lib/src/DnsUtils.dart
@@ -19,14 +19,18 @@ class DnsUtils {
   ///
   static Future<List<RRecord>?> lookupRecord(String name, RRecordType type,
       {bool dnssec = false,
-      DnsApiProvider provider = DnsApiProvider.GOOGLE}) async {
+      DnsApiProvider provider = DnsApiProvider.GOOGLE,
+      String? dnsApiUrl}) async {
     var queryParameters = <String, dynamic>{};
     queryParameters.putIfAbsent('name', () => name);
     queryParameters.putIfAbsent('type', () => _getTypeFromType(type));
     queryParameters.putIfAbsent('dnssec', () => dnssec.toString());
 
-    assert(_dnsApiProviderUrl.length == DnsApiProvider.values.length);
-    var _baseUrl = _dnsApiProviderUrl[provider];
+    var _baseUrl = dnsApiUrl;
+    if (_baseUrl == null) {
+      assert(_dnsApiProviderUrl.length == DnsApiProvider.values.length);
+      _baseUrl = _dnsApiProviderUrl[provider];
+    }
 
     var headers = {'Accept': 'application/dns-json'};
 

--- a/lib/src/DnsUtils.dart
+++ b/lib/src/DnsUtils.dart
@@ -17,6 +17,9 @@ class DnsUtils {
   ///
   /// Lookup for records of the given [type] and [name]. It also supports [dnssec]
   ///
+  /// [dnsApiUrl] allows the caller to specify a custom DNS API URL. If this parameter
+  /// is not provided, the URL will be determined based on the [provider].
+  ///
   static Future<List<RRecord>?> lookupRecord(String name, RRecordType type,
       {bool dnssec = false,
       DnsApiProvider provider = DnsApiProvider.GOOGLE,


### PR DESCRIPTION
Hi  (☞ﾟヮﾟ)☞

I added a new parameter to let us customize the DNS API URL. This should help with issues in certain regions. Such as China, Google DNS isn't accessible, and Cloudflare DNS can be slow because they don't have local servers there.
