### PR TITLE
Correct curve name of ECPublicKey and ECPrivateKey

### DIFF
--- a/lib/src/CryptoUtils.dart
+++ b/lib/src/CryptoUtils.dart
@@ -692,7 +692,7 @@ class CryptoUtils {
       var b2Data = b2.objectIdentifierAsString;
       var b2Curvedata = ObjectIdentifiers.getIdentifierByIdentifier(b2Data);
       if (b2Curvedata != null) {
-        curveName = b2Curvedata['readableName'];
+        curveName = b2Curvedata['readableName'].toLowerCase();
       }
 
       var octetString = topLevelSeq.elements!.elementAt(2) as ASN1OctetString;
@@ -716,7 +716,7 @@ class CryptoUtils {
       var data = ObjectIdentifiers.getIdentifierByIdentifier(
           curveNameOi.objectIdentifierAsString);
       if (data != null) {
-        curveName = data['readableName'];
+        curveName = data['readableName'].toLowerCase();
       }
 
       x = privateKeyAsOctetString.valueBytes!;
@@ -746,7 +746,7 @@ class CryptoUtils {
     var data = ObjectIdentifiers.getIdentifierByIdentifier(
         curveNameOi.objectIdentifierAsString);
     if (data != null) {
-      curveName = data['readableName'];
+      curveName = data['readableName'].toLowerCase();
     }
 
     var subjectPublicKey = topLevelSeq.elements![1] as ASN1BitString;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: dart_internal
-      sha256: dae3976f383beddcfcd07ad5291a422df2c8c0a8a03c52cda63ac7b4f26e0f4e
+      sha256: "781e0d03812e5b52fdc3f71540b178245021be64d22cbc88da2aee6b45705183"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.8"
+    version: "0.2.13"
   dart_style:
     dependency: transitive
     description:
@@ -546,4 +546,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <3.2.0"
+  dart: ">=3.0.0 <3.7.0"


### PR DESCRIPTION
The curve name get from `readableName` field can contain uppercase but the curve name from [ECCurve](https://pub.dev/documentation/pointycastle/latest/impl.ecc.ecc_base/ECDomainParametersImpl-class.html) is lowercase only so it is better to cast the `readableName` to lowercase.