### PR TITLE
Added DER Bytes encoding as alternative to PEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ AsymmetricKeyPair generateRSAKeyPair({int keySize = 2048});
 AsymmetricKeyPair generateEcKeyPair({String curve = 'prime256v1'});
 String encodeRSAPublicKeyToPem(RSAPublicKey publicKey);
 String encodeRSAPrivateKeyToPem(RSAPrivateKey rsaPrivateKey);
+Uint8List encodeRSAPublicKeyToDERBytes(RSAPublicKey publicKey);
+Uint8List encodeRSAPrivateKeyToDERBytes(RSAPrivateKey privateKey);
 RSAPrivateKey rsaPrivateKeyFromPem(String pem);
 RSAPublicKey rsaPublicKeyFromPem(String pem);
 RSAPrivateKey rsaPrivateKeyFromDERBytes(Uint8List bytes);

--- a/test/crypto_utils_test.dart
+++ b/test/crypto_utils_test.dart
@@ -151,12 +151,28 @@ sF0zEAHkQoYVBEhrfAHOLYkE3u08+q2tug==
     expect(pem.endsWith('-----END PRIVATE KEY-----'), true);
   });
 
+  test('Test encodeRSAPrivateKeyToDERBytes', () {
+    var pair = CryptoUtils.generateRSAKeyPair();
+    var derBytes = CryptoUtils.encodeRSAPrivateKeyToDERBytes(
+        pair.privateKey as RSAPrivateKey);
+    var privateKey = CryptoUtils.rsaPrivateKeyFromDERBytes(derBytes);
+    expect(privateKey, pair.privateKey);
+  });
+
   test('Test encodeRSAPublicKeyToPem', () {
     var pair = CryptoUtils.generateRSAKeyPair();
     var pem =
         CryptoUtils.encodeRSAPublicKeyToPem(pair.publicKey as RSAPublicKey);
     expect(pem.startsWith('-----BEGIN PUBLIC KEY-----'), true);
     expect(pem.endsWith('-----END PUBLIC KEY-----'), true);
+  });
+
+  test('Test encodeRSAPublicKeyToDERBytes', () {
+    var pair = CryptoUtils.generateRSAKeyPair();
+    var derBytes = CryptoUtils.encodeRSAPublicKeyToDERBytes(
+        pair.publicKey as RSAPublicKey);
+    var publicKey = CryptoUtils.rsaPublicKeyFromDERBytes(derBytes);
+    expect(publicKey, pair.publicKey);
   });
 
   test('Test encodeRSAPrivateKeyToPemPkcs1', () {
@@ -431,9 +447,10 @@ sF0zEAHkQoYVBEhrfAHOLYkE3u08+q2tug==
   });
 
   test('Test encodeEcPrivateKeyToPkcs8', () {
-    var ecdsaKeypair = CryptoUtils.generateEcKeyPair(); 
-    var ecPrivateKeyPkcs8 = CryptoUtils.encodePrivateEcdsaKeyToPkcs8(ecdsaKeypair.privateKey as ECPrivateKey); 
+    var ecdsaKeypair = CryptoUtils.generateEcKeyPair();
+    var ecPrivateKeyPkcs8 = CryptoUtils.encodePrivateEcdsaKeyToPkcs8(
+        ecdsaKeypair.privateKey as ECPrivateKey);
 
-    expect(ecPrivateKeyPkcs8.startsWith('-----BEGIN PRIVATE KEY-----'), true); 
+    expect(ecPrivateKeyPkcs8.startsWith('-----BEGIN PRIVATE KEY-----'), true);
   });
 }


### PR DESCRIPTION
## Info
Some applications not only deliver the DER Bytes, but also need them again in favour of a full PEM file. Instead of converting to PEM and removing the BEGIN and END block, this adds two more functions, helping with DER Bytes encoding.

As i needed this for my application, i added it to the lib, maybe someone else will benefit from.

Thanks however for this good lib!
