### PR TITLE
Custom X509CertificateDataExtensions

### DIFF
--- a/lib/src/X509Utils.dart
+++ b/lib/src/X509Utils.dart
@@ -2146,15 +2146,15 @@ class X509Utils {
             _fetchAuthorityInfoAccess(seq.elements!.elementAt(1));
         extensions.authorityInfoAccess = authorityInfoAccess;
       } else if (ObjectIdentifiers.getIdentifierByIdentifier(
-              oi.objectIdentifierAsString!) !=
+              oi.objectIdentifierAsString!) ==
           null) {
-        print("Parser for ${oi.objectIdentifierAsString} not implemented.");
-      } else {
         var extValue = _fetchCustomExtensionFromSeq(seq);
 
         // Add the extension value to the custom extensions map
         extensions.customExtensions ??= {};
         extensions.customExtensions![oi.objectIdentifierAsString!] = extValue;
+      } else {
+        print("Parser for ${oi.objectIdentifierAsString} not implemented.");
       }
     });
     return extensions;

--- a/lib/src/X509Utils.dart
+++ b/lib/src/X509Utils.dart
@@ -2142,7 +2142,6 @@ class X509Utils {
             _fetchSubjectKeyIdentifier(seq.elements!.elementAt(1));
         extensions.subjectKeyIdentifier = subjectKeyIdentifier;
       } else if (oi.objectIdentifierAsString == "1.3.6.1.5.5.7.1.1") {
-        print("Implement Authority Info Access");
         var authorityInfoAccess =
             _fetchAuthorityInfoAccess(seq.elements!.elementAt(1));
         extensions.authorityInfoAccess = authorityInfoAccess;

--- a/lib/src/X509Utils.dart
+++ b/lib/src/X509Utils.dart
@@ -554,9 +554,21 @@ class X509Utils {
   /// * SHA-384
   /// * SHA-512
   ///
-  static String generateEccCsrPem(Map<String, String> attributes,
-      ECPrivateKey privateKey, ECPublicKey publicKey,
-      {List<String>? san, String signingAlgorithm = 'SHA-256'}) {
+  /// [extensions] defines custom extensions to be placed within the CSR. 
+  /// Each extension should have a valid OID. Valid types for an extension value are:
+  /// * int
+  /// * String
+  /// * List<String>
+  /// * bool
+  /// 
+  static String generateEccCsrPem(
+    Map<String, String> attributes,
+    ECPrivateKey privateKey,
+    ECPublicKey publicKey, {
+    List<String>? san,
+    String signingAlgorithm = 'SHA-256',
+    Map<String, dynamic>? extensions,
+  }) {
     if (!_validRsaSigner.contains(signingAlgorithm)) {
       ArgumentError('Signingalgorithm $signingAlgorithm not supported!');
     }
@@ -567,32 +579,70 @@ class X509Utils {
     blockDN.add(ASN1Integer(BigInt.from(0)));
     blockDN.add(encodedDN);
     blockDN.add(publicKeySequence);
-    // Check if extensions are needed
+
+    // Compatibility with old code (subjectAltName)
     if (san != null && san.isNotEmpty) {
-      var outerBlockExt = ASN1Sequence();
-      outerBlockExt.add(ASN1ObjectIdentifier.fromName('extensionRequest'));
+      extensions ??= {};
+      extensions['2.5.29.17'] = san;
+    }
 
-      var setExt = ASN1Set();
+    if (extensions != null && extensions.isNotEmpty) {
+      // Extensions -> Sequence(OID, Set)
+      // Set -> Sequence(Extension[])
+      // Extension -> Sequence(OID, Critical?, Value)
+      // Value -> OctetString(ASN1Object)
+      var extensionsSeq = ASN1Sequence();
+      extensionsSeq.add(ASN1ObjectIdentifier.fromName('extensionRequest'));
 
-      var innerBlockExt = ASN1Sequence();
+      var extensionsSet = ASN1Set();
+      var setSeq = ASN1Sequence();
 
-      var sanExtSeq = ASN1Sequence();
-      sanExtSeq.add(ASN1ObjectIdentifier.fromName('subjectAltName'));
-      var sanSeq = ASN1Sequence();
-      for (var s in san) {
-        var sanIa5 = ASN1IA5String(stringValue: s, tag: 0x82);
-        sanSeq.add(sanIa5);
+      for (var ext in extensions.entries) {
+        var extension = ASN1Sequence();
+        ASN1ObjectIdentifier obj = ASN1ObjectIdentifier.fromIdentifierString(
+          ext.key,
+        );
+
+        extension.add(obj);
+        var critical = ASN1Boolean(false);
+        extension.add(critical);
+
+        // Creates the (subclass of) ASN1Object based on the type of the value
+        if (ext.value is int) {
+          var integerValue = ASN1Integer(BigInt.from(ext.value));
+          var octet = ASN1OctetString(octets: integerValue.encode());
+          extension.add(octet);
+          setSeq.add(extension);
+        } else if (ext.value is String) {
+          var stringValue = ASN1OctetString(
+            octets: Uint8List.fromList(ext.value.codeUnits),
+          );
+          var octet = ASN1OctetString(octets: stringValue.encode());
+          extension.add(octet);
+          setSeq.add(extension);
+        } else if (ext.value is List<String>) {
+          var listValue = ASN1Sequence();
+          for (var s in ext.value) {
+            var stringValue = ASN1IA5String(stringValue: s, tag: 0x82);
+            listValue.add(stringValue);
+          }
+          var octet = ASN1OctetString(octets: listValue.encode());
+          extension.add(octet);
+          setSeq.add(extension);
+        } else if (ext.value is bool) {
+          var booleanValue = ASN1Boolean(ext.value);
+          var octet = ASN1OctetString(octets: booleanValue.encode());
+          extension.add(octet);
+          setSeq.add(extension);
+        } else {
+          throw ArgumentError('Unsupported type for extension value');
+        }
       }
-      var octet = ASN1OctetString(octets: sanSeq.encode());
-      sanExtSeq.add(octet);
 
-      innerBlockExt.add(sanExtSeq);
+      extensionsSet.add(setSeq);
+      extensionsSeq.add(extensionsSet);
 
-      setExt.add(innerBlockExt);
-
-      outerBlockExt.add(setExt);
-
-      var asn1Null = ASN1OctetString(tag: 0xA0, octets: outerBlockExt.encode());
+      var asn1Null = ASN1OctetString(tag: 0xA0, octets: extensionsSeq.encode());
       //asn1Null.valueBytes = outerBlockExt.encode();
       blockDN.add(asn1Null);
     } else {
@@ -1841,6 +1891,7 @@ class X509Utils {
         tbsCertificateSeq.elements!.elementAt(element + 6) as ASN1Sequence;
     var subjectPublicKeyInfo = _getSubjectPublicKeyInfoFromSeq(pubKeySequence);
 
+    // Extensions
     var extensions;
     if (version > 1 && tbsCertificateSeq.elements!.length > element + 7) {
       var extensionObject = tbsCertificateSeq.elements!.elementAt(element + 7);
@@ -1974,14 +2025,14 @@ class X509Utils {
   }
 
   static X509CertificateDataExtensions _getExtensionsFromSeq(
-      ASN1Sequence extSequence) {
+    ASN1Sequence extSequence,
+  ) {
     List<String>? sans;
     List<KeyUsage>? keyUsage;
     List<ExtendedKeyUsage>? extKeyUsage;
     List<dynamic> basicConstraints;
     var extensions = X509CertificateDataExtensions();
-    extSequence.elements!.forEach(
-      (ASN1Object subseq) {
+    extSequence.elements!.forEach((ASN1Object subseq) {
         var seq = subseq as ASN1Sequence;
         var oi = seq.elements!.elementAt(0) as ASN1ObjectIdentifier;
         if (oi.objectIdentifierAsString == '2.5.29.17') {
@@ -1994,8 +2045,9 @@ class X509Utils {
         }
 
         var keyUsageSequence = ASN1Sequence();
-        keyUsageSequence
-            .add(ASN1ObjectIdentifier.fromIdentifierString('2.5.29.15'));
+      keyUsageSequence.add(
+        ASN1ObjectIdentifier.fromIdentifierString('2.5.29.15'),
+      );
 
         if (oi.objectIdentifierAsString == '2.5.29.15') {
           if (seq.elements!.length == 3) {
@@ -2004,39 +2056,40 @@ class X509Utils {
             keyUsage = _fetchKeyUsageFromExtension(seq.elements!.elementAt(1));
           }
           extensions.keyUsage = keyUsage;
-        }
-        if (oi.objectIdentifierAsString == '2.5.29.37') {
+      } else if (oi.objectIdentifierAsString == '2.5.29.37') {
           if (seq.elements!.length == 3) {
-            extKeyUsage =
-                _fetchExtendedKeyUsageFromExtension(seq.elements!.elementAt(2));
+          extKeyUsage = _fetchExtendedKeyUsageFromExtension(
+            seq.elements!.elementAt(2),
+          );
           } else {
-            extKeyUsage =
-                _fetchExtendedKeyUsageFromExtension(seq.elements!.elementAt(1));
+          extKeyUsage = _fetchExtendedKeyUsageFromExtension(
+            seq.elements!.elementAt(1),
+          );
           }
           extensions.extKeyUsage = extKeyUsage;
-        }
-        if (oi.objectIdentifierAsString == '2.5.29.19') {
+      } else if (oi.objectIdentifierAsString == '2.5.29.19') {
           if (seq.elements!.length == 3) {
-            basicConstraints =
-                _fetchBasicConstraintsFromExtension(seq.elements!.elementAt(2));
+          basicConstraints = _fetchBasicConstraintsFromExtension(
+            seq.elements!.elementAt(2),
+          );
           } else {
             basicConstraints = [null, null];
           }
 
           extensions.cA = basicConstraints[0];
           extensions.pathLenConstraint = basicConstraints[1];
-        }
-        if (oi.objectIdentifierAsString == '1.3.6.1.5.5.7.1.12') {
+      } else if (oi.objectIdentifierAsString == '1.3.6.1.5.5.7.1.12') {
           var vmcData = _fetchVmcLogo(seq.elements!.elementAt(1));
           extensions.vmc = vmcData;
-        }
-        if (oi.objectIdentifierAsString == '2.5.29.31') {
-          var cRLDistributionPoints =
-              _fetchCrlDistributionPoints(seq.elements!.elementAt(1));
+      } else if (oi.objectIdentifierAsString == '2.5.29.31') {
+        var cRLDistributionPoints = _fetchCrlDistributionPoints(
+          seq.elements!.elementAt(1),
+        );
           extensions.cRLDistributionPoints = cRLDistributionPoints;
+      } else {
+        extensions.customExtensions ??= {};
         }
-      },
-    );
+    });
     return extensions;
   }
 
@@ -2054,12 +2107,12 @@ class X509Utils {
     var pubInfo = _getSubjectPublicKeyInfoFromSeq(pubSeq);
 
     // Extensions
-    var extensions;
+    var extensions = CertificateSigningRequestExtensions();
+
     if (infoSeq.elements!.length == 4) {
       var extensionObject = infoSeq.elements!.elementAt(3);
       if (extensionObject.valueByteLength != 0) {
         List<String>? sans;
-        extensions = CertificateSigningRequestExtensions();
         var extParser = ASN1Parser(extensionObject.valueBytes);
         while (extParser.hasNext()) {
           var outerExtSequence = extParser.nextObject() as ASN1Sequence;
@@ -2072,7 +2125,9 @@ class X509Utils {
             extSequence.elements!.forEach((ASN1Object subseq) {
               var seq = subseq as ASN1Sequence;
               var oi = seq.elements!.elementAt(0) as ASN1ObjectIdentifier;
+              // Verifies if SAN is present
               if (oi.objectIdentifierAsString == '2.5.29.17') {
+                // Verifies if CRITICAL is present
                 if (seq.elements!.length == 3) {
                   sans = _fetchSansFromExtension(seq.elements!.elementAt(2));
                 } else {
@@ -2080,11 +2135,48 @@ class X509Utils {
                 }
                 extensions.subjectAlternativNames = sans;
               }
+              // Parse other extensions (including custom extensions)
+              // Each extension value is encoded as an ASN1OctetString
+              else {
+                extensions.customExtensions ??= {};
+                var extValue;
+
+                // Verifies if CRITICAL is present
+                var octet = (seq.elements!.length == 3
+                    ? seq.elements!.elementAt(2)
+                    : seq.elements!.elementAt(1)) as ASN1OctetString;
+
+                var extParser = ASN1Parser(octet.valueBytes);
+                var extElement = extParser.nextObject();
+
+                // Extension value is a List<String>
+                if (extElement is ASN1Sequence) {
+                  extValue = [];
+                  extElement.elements!.forEach((ASN1Object san) {
+                    var octectString =
+                        ASN1OctetString.fromBytes(san.encodedBytes!);
+                    extValue.add(utf8.decode(octectString.valueBytes!));
+                  });
+                } else if (extElement is ASN1Integer) {
+                  extValue = extElement.integer?.toInt();
+                } else if (extElement is ASN1OctetString) {
+                  extValue = utf8.decode(extElement.valueBytes!);
+                } else if (extElement is ASN1Boolean) {
+                  extValue = extElement.boolValue;
+                } else {
+                  throw ArgumentError('Unsupported type ${extElement.runtimeType}) for extension value');
+                }
+
+                // Add the extension value to the custom extensions map
+                extensions.customExtensions![oi.objectIdentifierAsString!] =
+                    extValue;
+              }
             });
           }
         }
       }
     }
+
     return bu.CertificationRequestInfo(
       version: asn1Version.integer!.toInt(),
       subject: subject,

--- a/lib/src/X509Utils.dart
+++ b/lib/src/X509Utils.dart
@@ -34,10 +34,11 @@ import 'package:basic_utils/src/model/x509/X509CertificateData.dart';
 import 'package:basic_utils/src/model/x509/X509CertificateDataExtensions.dart';
 import 'package:basic_utils/src/model/x509/X509CertificatePublicKeyData.dart';
 import 'package:basic_utils/src/model/x509/X509CertificateValidity.dart';
-import 'package:pointycastle/asn1/unsupported_object_identifier_exception.dart';
 
 import 'package:pointycastle/export.dart';
 import 'package:pointycastle/pointycastle.dart';
+import 'package:pointycastle/asn1/object_identifiers.dart';
+import 'package:pointycastle/asn1/unsupported_object_identifier_exception.dart';
 
 ///
 /// Helper class for certificate operations.
@@ -587,9 +588,9 @@ class X509Utils {
     }
 
     if (extensions != null && extensions.isNotEmpty) {
-      // Extensions -> Sequence(OID, Set)
+      // Extensions -> Sequence(Extensions' OID, Set)
       // Set -> Sequence(Extension[])
-      // Extension -> Sequence(OID, Critical?, Value)
+      // Extension -> Sequence(custom OID, Critical?, Value)
       // Value -> OctetString(ASN1Object)
       var extensionsSeq = ASN1Sequence();
       extensionsSeq.add(ASN1ObjectIdentifier.fromName('extensionRequest'));
@@ -2027,6 +2028,55 @@ class X509Utils {
     );
   }
 
+  static _fetchSubjectKeyIdentifier(ASN1Object extData) {
+    var octet = extData as ASN1OctetString;
+    var parser = ASN1Parser(octet.valueBytes);
+    var keyIdentifier = parser.nextObject() as ASN1OctetString;
+    var hexKeyIdentifier = keyIdentifier.valueBytes!
+        .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
+        .join('');
+
+    return hexKeyIdentifier;
+  }
+
+  // TODO: RFC defines a different structure for the authority key identifier
+  static _fetchAuthorityKeyIdentifier(ASN1Object extData) {
+    try {
+      var octet = extData as ASN1OctetString;
+      var parser = ASN1Parser(octet.valueBytes);
+      var extSeq = parser.nextObject() as ASN1Sequence;
+      var keyIdentifier = extSeq.elements!.elementAt(0);
+      var hexKeyIdentifier = keyIdentifier.valueBytes!
+          .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
+          .join('');
+
+      return hexKeyIdentifier;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  static _fetchAuthorityInfoAccess(ASN1Object extData) {
+    var authorityInfoAccess = <String>[];
+    var octet = extData as ASN1OctetString;
+    var parser = ASN1Parser(octet.valueBytes);
+    var extSeq = parser.nextObject() as ASN1Sequence;
+    extSeq.elements!.forEach((ASN1Object subseq) {
+      var seq = subseq as ASN1Sequence;
+      var accessMethod = seq.elements!.elementAt(0) as ASN1ObjectIdentifier;
+      var accessLocationParser = ASN1Parser(
+        seq.elements!.elementAt(1).encodedBytes,
+      );
+      var accessLocation =
+          utf8.decode(accessLocationParser.nextObject().valueBytes!);
+
+      authorityInfoAccess.add(
+        '${accessMethod.objectIdentifierAsString}::${accessLocation}',
+      );
+    });
+    return authorityInfoAccess;
+  }
+
   static X509CertificateDataExtensions _getExtensionsFromSeq(
     ASN1Sequence extSequence,
   ) {
@@ -2045,15 +2095,7 @@ class X509Utils {
           sans = _fetchSansFromExtension(seq.elements!.elementAt(1));
         }
         extensions.subjectAlternativNames = sans;
-      }
-
-      // Useless?
-      // var keyUsageSequence = ASN1Sequence();
-      // keyUsageSequence.add(
-      //   ASN1ObjectIdentifier.fromIdentifierString('2.5.29.15'),
-      // );
-
-      else if (oi.objectIdentifierAsString == '2.5.29.15') {
+      } else if (oi.objectIdentifierAsString == '2.5.29.15') {
         if (seq.elements!.length == 3) {
           keyUsage = _fetchKeyUsageFromExtension(seq.elements!.elementAt(2));
         } else {
@@ -2092,16 +2134,27 @@ class X509Utils {
         );
         extensions.cRLDistributionPoints = cRLDistributionPoints;
       } else if (oi.objectIdentifierAsString == '2.5.29.35') {
-        print("Implement Authority Key Identifier");
+        var authorityKeyIdentifier =
+            _fetchAuthorityKeyIdentifier(seq.elements!.elementAt(1));
+        extensions.authorityKeyIdentifier = authorityKeyIdentifier;
       } else if (oi.objectIdentifierAsString == "2.5.29.14") {
-        print("Implement Subject Key Identifier");
+        var subjectKeyIdentifier =
+            _fetchSubjectKeyIdentifier(seq.elements!.elementAt(1));
+        extensions.subjectKeyIdentifier = subjectKeyIdentifier;
       } else if (oi.objectIdentifierAsString == "1.3.6.1.5.5.7.1.1") {
         print("Implement Authority Info Access");
+        var authorityInfoAccess =
+            _fetchAuthorityInfoAccess(seq.elements!.elementAt(1));
+        extensions.authorityInfoAccess = authorityInfoAccess;
+      } else if (ObjectIdentifiers.getIdentifierByName(
+              oi.objectIdentifierAsString!) !=
+          null) {
+        print("Parser for ${oi.objectIdentifierAsString} not implemented.");
       } else {
-        extensions.customExtensions ??= {};
         var extValue = _fetchCustomExtensionFromSeq(seq);
 
         // Add the extension value to the custom extensions map
+        extensions.customExtensions ??= {};
         extensions.customExtensions![oi.objectIdentifierAsString!] = extValue;
       }
     });
@@ -2149,8 +2202,13 @@ class X509Utils {
                   sans = _fetchSansFromExtension(seq.elements!.elementAt(1));
                 }
                 extensions.subjectAlternativNames = sans;
+              } else if (ObjectIdentifiers.getIdentifierByName(
+                      oi.objectIdentifierAsString!) !=
+                  null) {
+                print(
+                    "Parser for ${oi.objectIdentifierAsString} not implemented.");
               }
-              // Parse other extensions (including custom extensions)
+              // Parse custom extensions
               // Each extension value is encoded as an ASN1OctetString
               else {
                 extensions.customExtensions ??= {};

--- a/lib/src/X509Utils.dart
+++ b/lib/src/X509Utils.dart
@@ -2145,7 +2145,7 @@ class X509Utils {
         var authorityInfoAccess =
             _fetchAuthorityInfoAccess(seq.elements!.elementAt(1));
         extensions.authorityInfoAccess = authorityInfoAccess;
-      } else if (ObjectIdentifiers.getIdentifierByName(
+      } else if (ObjectIdentifiers.getIdentifierByIdentifier(
               oi.objectIdentifierAsString!) !=
           null) {
         print("Parser for ${oi.objectIdentifierAsString} not implemented.");
@@ -2201,15 +2201,12 @@ class X509Utils {
                   sans = _fetchSansFromExtension(seq.elements!.elementAt(1));
                 }
                 extensions.subjectAlternativNames = sans;
-              } else if (ObjectIdentifiers.getIdentifierByName(
-                      oi.objectIdentifierAsString!) !=
-                  null) {
-                print(
-                    "Parser for ${oi.objectIdentifierAsString} not implemented.");
               }
               // Parse custom extensions
               // Each extension value is encoded as an ASN1OctetString
-              else {
+              else if (ObjectIdentifiers.getIdentifierByIdentifier(
+                      oi.objectIdentifierAsString!) ==
+                  null) {
                 extensions.customExtensions ??= {};
 
                 var extValue = _fetchCustomExtensionFromSeq(seq);
@@ -2217,6 +2214,9 @@ class X509Utils {
                 // Add the extension value to the custom extensions map
                 extensions.customExtensions![oi.objectIdentifierAsString!] =
                     extValue;
+              } else {
+                print(
+                    "Parser for ${oi.objectIdentifierAsString} not implemented.");
               }
             });
           }
@@ -2263,8 +2263,8 @@ class X509Utils {
     } else if (extElement is ASN1Boolean) {
       extValue = extElement.boolValue;
     } else {
-      throw ArgumentError(
-          'Unsupported type (${extElement.runtimeType}) for extension value');
+      // Unsupported types -> return the raw value
+      extValue = extElement.valueBytes;
     }
 
     return extValue;

--- a/lib/src/X509Utils.dart
+++ b/lib/src/X509Utils.dart
@@ -554,13 +554,13 @@ class X509Utils {
   /// * SHA-384
   /// * SHA-512
   ///
-  /// [extensions] defines custom extensions to be placed within the CSR. 
+  /// [extensions] defines custom extensions to be placed within the CSR.
   /// Each extension should have a valid OID. Valid types for an extension value are:
   /// * int
   /// * String
   /// * List<String>
   /// * bool
-  /// 
+  ///
   static String generateEccCsrPem(
     Map<String, String> attributes,
     ECPrivateKey privateKey,
@@ -1037,6 +1037,9 @@ class X509Utils {
 
   ///
   /// Parses the given CSR [pem] to [CertificateSigningRequestData] object
+  ///
+  /// Note: When parsing the CSR extensions, if the extension value is invalid
+  /// the value won't be parsed, staying raw.
   ///
   static CertificateSigningRequestData csrFromPem(String pem) {
     var bytes = CryptoUtils.getBytesFromPEMString(pem);
@@ -2033,62 +2036,74 @@ class X509Utils {
     List<dynamic> basicConstraints;
     var extensions = X509CertificateDataExtensions();
     extSequence.elements!.forEach((ASN1Object subseq) {
-        var seq = subseq as ASN1Sequence;
-        var oi = seq.elements!.elementAt(0) as ASN1ObjectIdentifier;
-        if (oi.objectIdentifierAsString == '2.5.29.17') {
-          if (seq.elements!.length == 3) {
-            sans = _fetchSansFromExtension(seq.elements!.elementAt(2));
-          } else {
-            sans = _fetchSansFromExtension(seq.elements!.elementAt(1));
-          }
-          extensions.subjectAlternativNames = sans;
+      var seq = subseq as ASN1Sequence;
+      var oi = seq.elements!.elementAt(0) as ASN1ObjectIdentifier;
+      if (oi.objectIdentifierAsString == '2.5.29.17') {
+        if (seq.elements!.length == 3) {
+          sans = _fetchSansFromExtension(seq.elements!.elementAt(2));
+        } else {
+          sans = _fetchSansFromExtension(seq.elements!.elementAt(1));
         }
+        extensions.subjectAlternativNames = sans;
+      }
 
-        var keyUsageSequence = ASN1Sequence();
-      keyUsageSequence.add(
-        ASN1ObjectIdentifier.fromIdentifierString('2.5.29.15'),
-      );
+      // Useless?
+      // var keyUsageSequence = ASN1Sequence();
+      // keyUsageSequence.add(
+      //   ASN1ObjectIdentifier.fromIdentifierString('2.5.29.15'),
+      // );
 
-        if (oi.objectIdentifierAsString == '2.5.29.15') {
-          if (seq.elements!.length == 3) {
-            keyUsage = _fetchKeyUsageFromExtension(seq.elements!.elementAt(2));
-          } else {
-            keyUsage = _fetchKeyUsageFromExtension(seq.elements!.elementAt(1));
-          }
-          extensions.keyUsage = keyUsage;
+      else if (oi.objectIdentifierAsString == '2.5.29.15') {
+        if (seq.elements!.length == 3) {
+          keyUsage = _fetchKeyUsageFromExtension(seq.elements!.elementAt(2));
+        } else {
+          keyUsage = _fetchKeyUsageFromExtension(seq.elements!.elementAt(1));
+        }
+        extensions.keyUsage = keyUsage;
       } else if (oi.objectIdentifierAsString == '2.5.29.37') {
-          if (seq.elements!.length == 3) {
+        if (seq.elements!.length == 3) {
           extKeyUsage = _fetchExtendedKeyUsageFromExtension(
             seq.elements!.elementAt(2),
           );
-          } else {
+        } else {
           extKeyUsage = _fetchExtendedKeyUsageFromExtension(
             seq.elements!.elementAt(1),
           );
-          }
-          extensions.extKeyUsage = extKeyUsage;
+        }
+        extensions.extKeyUsage = extKeyUsage;
       } else if (oi.objectIdentifierAsString == '2.5.29.19') {
-          if (seq.elements!.length == 3) {
+        if (seq.elements!.length == 3) {
+          // Basic Constraints' critical is always present ?
           basicConstraints = _fetchBasicConstraintsFromExtension(
             seq.elements!.elementAt(2),
           );
-          } else {
-            basicConstraints = [null, null];
-          }
+        } else {
+          basicConstraints = [null, null];
+        }
 
-          extensions.cA = basicConstraints[0];
-          extensions.pathLenConstraint = basicConstraints[1];
+        extensions.cA = basicConstraints[0];
+        extensions.pathLenConstraint = basicConstraints[1];
       } else if (oi.objectIdentifierAsString == '1.3.6.1.5.5.7.1.12') {
-          var vmcData = _fetchVmcLogo(seq.elements!.elementAt(1));
-          extensions.vmc = vmcData;
+        var vmcData = _fetchVmcLogo(seq.elements!.elementAt(1));
+        extensions.vmc = vmcData;
       } else if (oi.objectIdentifierAsString == '2.5.29.31') {
         var cRLDistributionPoints = _fetchCrlDistributionPoints(
           seq.elements!.elementAt(1),
         );
-          extensions.cRLDistributionPoints = cRLDistributionPoints;
+        extensions.cRLDistributionPoints = cRLDistributionPoints;
+      } else if (oi.objectIdentifierAsString == '2.5.29.35') {
+        print("Implement Authority Key Identifier");
+      } else if (oi.objectIdentifierAsString == "2.5.29.14") {
+        print("Implement Subject Key Identifier");
+      } else if (oi.objectIdentifierAsString == "1.3.6.1.5.5.7.1.1") {
+        print("Implement Authority Info Access");
       } else {
         extensions.customExtensions ??= {};
-        }
+        var extValue = _fetchCustomExtensionFromSeq(seq);
+
+        // Add the extension value to the custom extensions map
+        extensions.customExtensions![oi.objectIdentifierAsString!] = extValue;
+      }
     });
     return extensions;
   }
@@ -2139,33 +2154,8 @@ class X509Utils {
               // Each extension value is encoded as an ASN1OctetString
               else {
                 extensions.customExtensions ??= {};
-                var extValue;
 
-                // Verifies if CRITICAL is present
-                var octet = (seq.elements!.length == 3
-                    ? seq.elements!.elementAt(2)
-                    : seq.elements!.elementAt(1)) as ASN1OctetString;
-
-                var extParser = ASN1Parser(octet.valueBytes);
-                var extElement = extParser.nextObject();
-
-                // Extension value is a List<String>
-                if (extElement is ASN1Sequence) {
-                  extValue = [];
-                  extElement.elements!.forEach((ASN1Object san) {
-                    var octectString =
-                        ASN1OctetString.fromBytes(san.encodedBytes!);
-                    extValue.add(utf8.decode(octectString.valueBytes!));
-                  });
-                } else if (extElement is ASN1Integer) {
-                  extValue = extElement.integer?.toInt();
-                } else if (extElement is ASN1OctetString) {
-                  extValue = utf8.decode(extElement.valueBytes!);
-                } else if (extElement is ASN1Boolean) {
-                  extValue = extElement.boolValue;
-                } else {
-                  throw ArgumentError('Unsupported type ${extElement.runtimeType}) for extension value');
-                }
+                var extValue = _fetchCustomExtensionFromSeq(seq);
 
                 // Add the extension value to the custom extensions map
                 extensions.customExtensions![oi.objectIdentifierAsString!] =
@@ -2183,6 +2173,44 @@ class X509Utils {
       publicKeyInfo: pubInfo,
       extensions: extensions,
     );
+  }
+
+  static _fetchCustomExtensionFromSeq(ASN1Sequence seq) {
+    var extValue;
+
+    // Verifies if CRITICAL is present
+    var octet = (seq.elements!.length == 3
+        ? seq.elements!.elementAt(2)
+        : seq.elements!.elementAt(1)) as ASN1OctetString;
+
+    var extParser = ASN1Parser(octet.valueBytes);
+    var extElement = extParser.nextObject();
+
+    // Extension value is a List<String>
+    if (extElement is ASN1Sequence) {
+      extValue = [];
+      extElement.elements!.forEach((ASN1Object asn) {
+        var octectString = ASN1OctetString.fromBytes(asn.encodedBytes!);
+        extValue.add(utf8.decode(octectString.valueBytes!));
+      });
+    } else if (extElement is ASN1Integer) {
+      extValue = extElement.integer?.toInt();
+    } else if (extElement is ASN1OctetString || extElement is ASN1BitString) {
+      try {
+        extValue = utf8.decode(extElement.valueBytes!);
+      } catch (e) {
+        extValue = extElement.valueBytes;
+      }
+    } else if (extElement is ASN1UTF8String) {
+      extValue = utf8.decode(extElement.valueBytes!);
+    } else if (extElement is ASN1Boolean) {
+      extValue = extElement.boolValue;
+    } else {
+      throw ArgumentError(
+          'Unsupported type (${extElement.runtimeType}) for extension value');
+    }
+
+    return extValue;
   }
 
   ///

--- a/lib/src/model/csr/CertificateSigningRequestExtensions.dart
+++ b/lib/src/model/csr/CertificateSigningRequestExtensions.dart
@@ -18,9 +18,11 @@ class CertificateSigningRequestExtensions {
   // certificatePolicies
   // authorityInfoAccess => OCSP und caIssuers
 
-  CertificateSigningRequestExtensions({
-    this.subjectAlternativNames,
-  });
+  // Custom extensions that are not defined on RFC 5280
+  Map<String, dynamic>? customExtensions;
+
+  CertificateSigningRequestExtensions(
+      {this.subjectAlternativNames, this.customExtensions});
 
   /*
    * Json to CertificateSigningRequestExtensions object

--- a/lib/src/model/csr/CertificateSigningRequestExtensions.dart
+++ b/lib/src/model/csr/CertificateSigningRequestExtensions.dart
@@ -18,7 +18,7 @@ class CertificateSigningRequestExtensions {
   // certificatePolicies
   // authorityInfoAccess => OCSP und caIssuers
 
-  // Custom extensions that are not defined on RFC 5280
+  /// Custom user defined extensions
   Map<String, dynamic>? customExtensions;
 
   CertificateSigningRequestExtensions(

--- a/lib/src/model/csr/CertificateSigningRequestExtensions.g.dart
+++ b/lib/src/model/csr/CertificateSigningRequestExtensions.g.dart
@@ -13,6 +13,7 @@ CertificateSigningRequestExtensions
               (json['subjectAlternativNames'] as List<dynamic>?)
                   ?.map((e) => e as String)
                   .toList(),
+          customExtensions: json['customExtensions'] as Map<String, dynamic>?,
         );
 
 Map<String, dynamic> _$CertificateSigningRequestExtensionsToJson(
@@ -26,5 +27,6 @@ Map<String, dynamic> _$CertificateSigningRequestExtensionsToJson(
   }
 
   writeNotNull('subjectAlternativNames', instance.subjectAlternativNames);
+  writeNotNull('customExtensions', instance.customExtensions);
   return val;
 }

--- a/lib/src/model/x509/X509CertificateDataExtensions.dart
+++ b/lib/src/model/x509/X509CertificateDataExtensions.dart
@@ -31,6 +31,9 @@ class X509CertificateDataExtensions {
   /// The distribution points for the crl files. Normally a url.
   List<String>? cRLDistributionPoints;
 
+  // Custom extensions defined by the ISO that are not on RFC 5280
+  Map<String, dynamic>? customExtensions;
+
   X509CertificateDataExtensions({
     this.subjectAlternativNames,
     this.extKeyUsage,
@@ -39,6 +42,7 @@ class X509CertificateDataExtensions {
     this.pathLenConstraint,
     this.vmc,
     this.cRLDistributionPoints,
+    this.customExtensions,
   });
 
   /*

--- a/lib/src/model/x509/X509CertificateDataExtensions.dart
+++ b/lib/src/model/x509/X509CertificateDataExtensions.dart
@@ -31,6 +31,17 @@ class X509CertificateDataExtensions {
   /// The distribution points for the crl files. Normally a url.
   List<String>? cRLDistributionPoints;
 
+  /// The Suject Key Identifier Base64 encoded
+  String? subjectKeyIdentifier;
+
+  /// The Authority Key Identifier Base64 encoded
+  String? authorityKeyIdentifier;
+
+  /// The Authority Info Access extension. Contains OCSP and CA Issuers, for example.
+  ///
+  /// After parsing the X509 the format is as follows: "accessMethod::accessLocation"
+  List<String>? authorityInfoAccess;
+
   // Custom extensions defined by the ISO that are not on RFC 5280
   Map<String, dynamic>? customExtensions;
 
@@ -42,6 +53,9 @@ class X509CertificateDataExtensions {
     this.pathLenConstraint,
     this.vmc,
     this.cRLDistributionPoints,
+    this.subjectKeyIdentifier,
+    this.authorityKeyIdentifier,
+    this.authorityInfoAccess,
     this.customExtensions,
   });
 

--- a/lib/src/model/x509/X509CertificateDataExtensions.dart
+++ b/lib/src/model/x509/X509CertificateDataExtensions.dart
@@ -42,7 +42,7 @@ class X509CertificateDataExtensions {
   /// After parsing the X509 the format is as follows: "accessMethod::accessLocation"
   List<String>? authorityInfoAccess;
 
-  // Custom extensions defined by the ISO that are not on RFC 5280
+  /// Custom user defined extensions
   Map<String, dynamic>? customExtensions;
 
   X509CertificateDataExtensions({

--- a/lib/src/model/x509/X509CertificateDataExtensions.g.dart
+++ b/lib/src/model/x509/X509CertificateDataExtensions.g.dart
@@ -26,6 +26,7 @@ X509CertificateDataExtensions _$X509CertificateDataExtensionsFromJson(
       cRLDistributionPoints: (json['cRLDistributionPoints'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
+      customExtensions: json['customExtensions'] as Map<String, dynamic>?,
     );
 
 Map<String, dynamic> _$X509CertificateDataExtensionsToJson(
@@ -47,6 +48,7 @@ Map<String, dynamic> _$X509CertificateDataExtensionsToJson(
   writeNotNull('pathLenConstraint', instance.pathLenConstraint);
   writeNotNull('vmc', instance.vmc?.toJson());
   writeNotNull('cRLDistributionPoints', instance.cRLDistributionPoints);
+  writeNotNull('customExtensions', instance.customExtensions);
   return val;
 }
 

--- a/lib/src/model/x509/X509CertificateDataExtensions.g.dart
+++ b/lib/src/model/x509/X509CertificateDataExtensions.g.dart
@@ -26,6 +26,11 @@ X509CertificateDataExtensions _$X509CertificateDataExtensionsFromJson(
       cRLDistributionPoints: (json['cRLDistributionPoints'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
+      subjectKeyIdentifier: json['subjectKeyIdentifier'] as String?,
+      authorityKeyIdentifier: json['authorityKeyIdentifier'] as String?,
+      authorityInfoAccess: (json['authorityInfoAccess'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
       customExtensions: json['customExtensions'] as Map<String, dynamic>?,
     );
 
@@ -48,6 +53,9 @@ Map<String, dynamic> _$X509CertificateDataExtensionsToJson(
   writeNotNull('pathLenConstraint', instance.pathLenConstraint);
   writeNotNull('vmc', instance.vmc?.toJson());
   writeNotNull('cRLDistributionPoints', instance.cRLDistributionPoints);
+  writeNotNull('subjectKeyIdentifier', instance.subjectKeyIdentifier);
+  writeNotNull('authorityKeyIdentifier', instance.authorityKeyIdentifier);
+  writeNotNull('authorityInfoAccess', instance.authorityInfoAccess);
   writeNotNull('customExtensions', instance.customExtensions);
   return val;
 }


### PR DESCRIPTION
This PR is inspired by ISO 18013-5, in which I need to define some attributes and set them on the extensions of a certificate. Therefore, this PR:
- adds support for custom extensions
  - a new param on `generateEccCsrPem` to represent the custom extensions that a user wants to add to the CSR
    - the value of an extension can be `String`, `int`, `List<String>` or `bool`
    - I tried to maintain compatibility with the existing SAN extension
- adds parsing for new extensions on `X509CertificateDataExtensions` (subjectKeyIdentifier, authorityKeyIdentifier and authorityInfoAccess)
  - if it is a known extension and there is no parsing for it, it just prints that (change this? Maybe add `List<String> unsupportedExtensions` field, because throwing an Exception would block all parsing)


TODO:
- add support for custom extensions on `generateRsaCsrPem` (if `generateEccCsrPem` looks good)

Note:
- I couldn't get build_runner to run and change the *.g.dart files. Only if I set the minimum sdk version to 3.0.0. Since I don't know if you want that change, I modified these files by hand (despite the warning). If you want that, I can just commit that change
- Would help with #74 ?