### PR TITLE
Handle IA5 strings in X509Utils._getDnFromSeq()

### DIFF
--- a/lib/src/X509Utils.dart
+++ b/lib/src/X509Utils.dart
@@ -1879,6 +1879,9 @@ class X509Utils {
         } else if (object is ASN1TeletextString) {
           var objectTeletext = object;
           value = objectTeletext.stringValue;
+        } else if (object is ASN1IA5String) {
+          var objectIa5 = object;
+          value = objectIa5.stringValue;
         }
         dnData.putIfAbsent(o.objectIdentifierAsString!, () => value ?? '');
       }

--- a/lib/src/X509Utils.dart
+++ b/lib/src/X509Utils.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:archive/archive.dart';
+import 'package:archive/archive.dart' hide KeyParameter, Digest;
 import 'package:basic_utils/src/CryptoUtils.dart';
 import 'package:basic_utils/src/IterableUtils.dart';
 import 'package:basic_utils/src/StringUtils.dart';


### PR DESCRIPTION
When decoding a X509 subjectDN the email field was omitted since it is encoded as an ASN1IA5String. The _getDnFromSeq() did not handle IA5 strings. This pull request fixes that problem.
